### PR TITLE
Honeycomb.API.Auth: use throwIO

### DIFF
--- a/honeycomb.cabal
+++ b/honeycomb.cabal
@@ -4,16 +4,16 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c2000043dd70cb53eba49d090fa9d3c743db6b1e2eb56ee08319f732b8a633e7
+-- hash: 2a670d8927ccbe14b8715231c27dedb4b077025fdc2dd914a06603979fa1a011
 
 name:           honeycomb
-version:        0.0.0.4
+version:        0.1.0.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/honeycomb#readme>
 homepage:       https://github.com/iand675/hs-honeycomb#readme
 bug-reports:    https://github.com/iand675/hs-honeycomb/issues
-author:         Ian Duncan
+author:         Ian Duncan, Jade Lovelace
 maintainer:     ian@iankduncan.com
-copyright:      2021 Ian Duncan
+copyright:      2021 Ian Duncan, 2022 Mercury Technologies, Inc
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name:                honeycomb
-version:             0.0.0.4
+version:             0.1.0.0
 github:              "iand675/hs-honeycomb"
 license:             BSD3
-author:              "Ian Duncan"
+author:              "Ian Duncan, Jade Lovelace"
 maintainer:          "ian@iankduncan.com"
-copyright:           "2021 Ian Duncan"
+copyright:           "2021 Ian Duncan, 2022 Mercury Technologies, Inc"
 
 extra-source-files:
 - README.md

--- a/src/Honeycomb/API/Auth.hs
+++ b/src/Honeycomb/API/Auth.hs
@@ -1,7 +1,7 @@
 module Honeycomb.API.Auth (module Honeycomb.API.Auth.Types, getAuth) where
 
-import Control.Exception (throw)
-import Control.Monad.IO.Class (MonadIO)
+import Control.Exception (throwIO)
+import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Reader.Class (asks)
 import Data.Aeson (eitherDecode)
 import qualified Data.Text as T
@@ -21,5 +21,5 @@ getAuth = do
   case getResponseStatusCode r of
     200 -> case eitherDecode (responseBody r) of
       Right r -> pure r
-      Left r -> throw . JsonDecodeFailed . T.pack $ r
-    other -> throw $ FailureCode other (getResponseBody r)
+      Left r -> liftIO . throwIO . JsonDecodeFailed . T.pack $ r
+    other -> liftIO . throwIO $ FailureCode other (getResponseBody r)

--- a/src/Honeycomb/Client/Internal.hs
+++ b/src/Honeycomb/Client/Internal.hs
@@ -10,7 +10,7 @@ module Honeycomb.Client.Internal where
 
 import Chronos
 import Control.Concurrent.Async
-import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Reader.Class
 import Data.Aeson (FromJSON, ToJSON, Value, eitherDecode, encode)
 import qualified Data.ByteString.Lazy as L


### PR DESCRIPTION
I accidentally made this use `throw`, which is probably fine but should really be `throwIO`.